### PR TITLE
fix(client/main): infinite loop

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,6 +1,7 @@
 local QBCore = exports['qbx-core']:GetCoreObject()
 local emailSent = false
 local isBusy = false
+local inZone = false
 
 local function scrapVehicleAnim(time)
     time /= 1000
@@ -143,14 +144,15 @@ CreateThread(function()
                 if Config.UseTarget then
                     if k == 'deliver' then
                         local function onEnter()
+                            inZone = true
                             if cache.vehicle and not isBusy then
                                 exports['qbx-core']:DrawText(Lang:t('text.disassemble_vehicle'),'left')
                                 CreateThread(function()
-                                    while true do
+                                    while inZone do
                                         if IsControlPressed(0, 38) then
                                             exports['qbx-core']:HideText()
                                             scrapVehicle()
-                                            break
+                                            return
                                         end
                                         Wait(0)
                                     end
@@ -159,6 +161,7 @@ CreateThread(function()
                         end
     
                         local function onExit()
+                            inZone = false
                             exports['qbx-core']:HideText()
                         end
     
@@ -194,14 +197,15 @@ CreateThread(function()
                 else
                     if k == 'deliver' then
                         local function onEnter()
+                            inZone = true
                             if cache.vehicle and not isBusy then
                                 exports['qbx-core']:DrawText(Lang:t('text.disassemble_vehicle'),'left')
                                 CreateThread(function()
-                                    while true do
+                                    while inZone do
                                         if IsControlPressed(0, 38) then
                                             exports['qbx-core']:HideText()
                                             scrapVehicle()
-                                            break
+                                            return
                                         end
                                         Wait(0)
                                     end
@@ -210,6 +214,7 @@ CreateThread(function()
                         end
     
                         local function onExit()
+                            inZone = false
                             exports['qbx-core']:HideText()
                         end
     
@@ -223,14 +228,15 @@ CreateThread(function()
                         })
                     else
                         local function onEnter()
+                            inZone = true
                             if not cache.vehicle and not isBusy then
                                 exports['qbx-core']:DrawText(Lang:t('text.email_list_target'), 'left')
                                 CreateThread(function()
-                                    while true do
+                                    while inZone do
                                         if IsControlPressed(0, 38) then
                                             exports['qbx-core']:HideText()
                                             createListEmail()
-                                            break
+                                            return
                                         end
                                         Wait(0)
                                     end
@@ -239,6 +245,7 @@ CreateThread(function()
                         end
     
                         local function onExit()
+                            inZone = false
                             exports['qbx-core']:HideText()
                         end
     


### PR DESCRIPTION
## Description

Fixes bug where when you leave the zone, loop checking for key press event still exists. Leaving and entering the zone without pressing the button causes multiple threads to exist all running the same loop. Solved by changing the condition of the loop to only be true while in a zone. Since they all share the same value, this would pose a problem if two zones overlapped, so I'm assuming that they do not and never will.

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
