### PR TITLE
refactor: move `currentVehicles` out of config

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,6 +1,6 @@
 local config = require 'config.client'
-local sharedConfig = require 'config.shared'
 local VEHICLES = exports.qbx_core:GetVehiclesByName()
+local currentVehicles = {}
 local emailSent = false
 local isBusy = false
 
@@ -23,11 +23,11 @@ local function scrapVehicleAnim(time)
 end
 
 local function getVehicleKey(vehicleModel)
-    if not sharedConfig.currentVehicles or table.type(sharedConfig.currentVehicles) == 'empty' then
+    if not currentVehicles or table.type(currentVehicles) == 'empty' then
         return 0
     end
 
-    for k, v in pairs(sharedConfig.currentVehicles) do
+    for k, v in pairs(currentVehicles) do
         if joaat(v) == vehicleModel then
             return k
         end
@@ -37,11 +37,11 @@ local function getVehicleKey(vehicleModel)
 end
 
 local function isVehicleValid(vehicleModel)
-    if not sharedConfig.currentVehicles or table.type(sharedConfig.currentVehicles) == 'empty' then
+    if not currentVehicles or table.type(currentVehicles) == 'empty' then
         return false
     end
 
-    for _, v in pairs(sharedConfig.currentVehicles) do
+    for _, v in pairs(currentVehicles) do
         if joaat(v) == vehicleModel then
             return true
         end
@@ -95,14 +95,14 @@ end
 
 local function createListEmail()
     if cache.vehicle then return end
-    if not sharedConfig.currentVehicles or table.type(sharedConfig.currentVehicles) == 'empty' then
+    if not currentVehicles or table.type(currentVehicles) == 'empty' then
        exports.qbx_core:Notify(Lang:t('error.demolish_vehicle'), 'error')
         return
     end
 
     emailSent = true
     local vehicleList = ""
-    for _, v in pairs(sharedConfig.currentVehicles) do
+    for _, v in pairs(currentVehicles) do
         local vehicleInfo = VEHICLES[v]
         if vehicleInfo then
             vehicleList = vehicleList  .. vehicleInfo["brand"] .. " " .. vehicleInfo["name"] .. "<br />"
@@ -125,7 +125,7 @@ RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
 end)
 
 RegisterNetEvent('qb-scapyard:client:setNewVehicles', function(vehicleList)
-    sharedConfig.currentVehicles = vehicleList
+    currentVehicles = vehicleList
 end)
 
 CreateThread(function()

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,3 +1,0 @@
-return {
-    currentVehicles = {}
-}

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -22,7 +22,6 @@ server_scripts {
 
 files {
     'config/client.lua',
-    'config/shared.lua'
 }
 
 provide 'qb-scrapyard'

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,12 +1,12 @@
 local config = require 'config.server'
-local sharedConfig = require 'config.shared'
 local ITEMS = exports.ox_inventory:Items()
+local currentVehicles = {}
 
 local function isInList(name)
     local retval = false
-    if sharedConfig.currentVehicles ~= nil and next(sharedConfig.currentVehicles) ~= nil then
-        for k in pairs(sharedConfig.currentVehicles) do
-            if sharedConfig.currentVehicles[k] == name then
+    if currentVehicles ~= nil and next(currentVehicles) ~= nil then
+        for k in pairs(currentVehicles) do
+            if currentVehicles[k] == name then
                 retval = true
             end
         end
@@ -15,14 +15,14 @@ local function isInList(name)
 end
 
 local function generateVehicleList()
-    sharedConfig.currentVehicles = {}
+    currentVehicles = {}
     for i = 1, 40, 1 do
         local randVehicle = config.vehicles[math.random(1, #config.vehicles)]
         if not isInList(randVehicle) then
-            sharedConfig.currentVehicles[i] = randVehicle
+            currentVehicles[i] = randVehicle
         end
     end
-    TriggerClientEvent("qb-scapyard:client:setNewVehicles", -1, sharedConfig.currentVehicles)
+    TriggerClientEvent("qb-scapyard:client:setNewVehicles", -1, currentVehicles)
 end
 
 lib.callback.register('qb-scrapyard:server:checkOwnerVehicle', function(_, plate)
@@ -35,13 +35,13 @@ lib.callback.register('qb-scrapyard:server:checkOwnerVehicle', function(_, plate
 end)
 
 RegisterNetEvent('qb-scrapyard:server:LoadVehicleList', function()
-    TriggerClientEvent("qb-scapyard:client:setNewVehicles", source, sharedConfig.currentVehicles)
+    TriggerClientEvent("qb-scapyard:client:setNewVehicles", source, currentVehicles)
 end)
 
 RegisterNetEvent('qb-scrapyard:server:ScrapVehicle', function(listKey)
     local src = source
     local Player = exports.qbx_core:GetPlayer(src)
-    if not Player or not sharedConfig.currentVehicles[listKey] then return end
+    if not Player or not currentVehicles[listKey] then return end
 
     for _ = 1, math.random(2, 4), 1 do
         local item = config.items[math.random(1, #config.items)]
@@ -58,8 +58,8 @@ RegisterNetEvent('qb-scrapyard:server:ScrapVehicle', function(listKey)
         TriggerClientEvent('inventory:client:ItemBox', src, ITEMS["rubber"], 'add')
     end
 
-    sharedConfig.currentVehicles[listKey] = nil
-    TriggerClientEvent("qb-scapyard:client:setNewVehicles", -1, sharedConfig.currentVehicles)
+    currentVehicles[listKey] = nil
+    TriggerClientEvent("qb-scapyard:client:setNewVehicles", -1, currentVehicles)
 end)
 
 CreateThread(function()


### PR DESCRIPTION
## Description

`currentVehicles` holds runtime data and isn't really a configurable value, so move it out of the config.
Since it was the only thing inside the shared config, remove the shared config too.

See https://github.com/Qbox-project/qbx_scrapyard/pull/13#pullrequestreview-1778308538 for additional context.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
